### PR TITLE
toggle_string_cache() fix in polars >= 0.17.0

### DIFF
--- a/gtfparse/read_gtf.py
+++ b/gtfparse/read_gtf.py
@@ -85,7 +85,10 @@ def parse_with_polars_lazy(
         fix_quotes_columns=["attribute"]):
     # use a global string cache so that all strings get intern'd into
     # a single numbering system
-    polars.enable_string_cache(True)
+    if version.parse(polars.__version__) >= version.parse("0.17.0"):
+        polars.enable_string_cache(True)
+    else:
+        polars.toggle_string_cache(True)
             
     kwargs = dict(
         has_header=False,

--- a/gtfparse/read_gtf.py
+++ b/gtfparse/read_gtf.py
@@ -85,7 +85,7 @@ def parse_with_polars_lazy(
         fix_quotes_columns=["attribute"]):
     # use a global string cache so that all strings get intern'd into
     # a single numbering system
-    polars.toggle_string_cache(True)
+    polars.enable_string_cache(True)
             
     kwargs = dict(
         has_header=False,


### PR DESCRIPTION
Polars v0.17.0 renamed toggle_string_cache() to enable_string_cache() and causes an error, this change fixes it and maintains backwards compatibility if polars is old